### PR TITLE
onThink behaviors bug

### DIFF
--- a/bots/botbraincore.lua
+++ b/bots/botbraincore.lua
@@ -143,7 +143,7 @@ function object:onthink(tGameVariables)
 	core.ProcessChatMessages(self)
 	StopProfile()
 
-	if core.unitSelf:GetHealth() <= 0 then
+	if not core.unitSelf:IsAlive() then
 		StopProfile()
 		return
 	end

--- a/bots/wretchedhag/WretchedHag_main.lua
+++ b/bots/wretchedhag/WretchedHag_main.lua
@@ -488,11 +488,6 @@ local function HarassHeroExecuteOverride(botBrain)
         if bCanSeeTarget then
                 nTargetMagicEHP = unitTarget:GetHealth() / (1 - unitTarget:GetMagicResistance())
         end
- 
-        -- Stop the bot from trying to harass heroes while dead
-        if not bActionTaken and not unitSelf:IsAlive() then
-                bActionTaken = true
-        end
        
         -- Hellflower
         if not bActionTaken then
@@ -748,11 +743,6 @@ local function AbilityPush(botBrain)
         local abilScream = skills.abilScream
         local unitSelf = core.unitSelf
         local nMinimumCreeps = 3
-       
-        -- Stop the bot from trying to farm creeps if the creeps approach the spot where the bot died
-        if not unitSelf:IsAlive() then
-                return bSuccess
-        end
        
         --Don't use Scream if it would put mana too low
         if abilScream:CanActivate() and unitSelf:GetManaPercent() > .32 then


### PR DESCRIPTION
GetHealth() returns a number greater than zero for the first 0-3 frames after a bot dies. This has the potential to cause behaviors to run while the bot is dead.

This is a fix for that bug by switching GetHealth() to IsAlive(). I also removed the code in Wretched Hag's main file meant to suppress this error.
